### PR TITLE
added rmats comparison data file

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -1,0 +1,63 @@
+# release notes
+
+## current release (v5)
+- Data release data: 2023-05-26
+- OpenPedCan data release date: 2023-04-30 (v12)
+- status: available
+
+Additional files:
+- `splice-events-rmats.tsv.gz`: merged matrix of rMATs splice events, run as single sample
+- `rMATS_merged.comparison.tsv.gz`: Midline HGG sample splice events compared to non-diseased brainstem, run using rMATs 
+- `release-notes.md`: specific release notes to this repository
+
+```
+v5
+├── cnv-consensus.seg.gz
+├── consensus_wgs_plus_cnvkit_wxs.tsv.gz
+├── fusion-putative-oncogenic.tsv
+├── gene-counts-rsem-expected_count-collapsed.rds
+├── gene-expression-rsem-tpm-collapsed.rds
+├── histologies.tsv
+├── independent-specimens.rnaseqpanel.primary-plus.tsv
+├── independent-specimens.rnaseqpanel.primary.tsv
+├── independent-specimens.wgswxspanel.primary-plus.prefer.wgs.tsv
+├── independent-specimens.wgswxspanel.primary-plus.prefer.wxs.tsv
+├── independent-specimens.wgswxspanel.primary.prefer.wgs.tsv
+├── independent-specimens.wgswxspanel.primary.prefer.wxs.tsv
+├── md5sum.txt
+├── rMATS_merged.comparison.tsv.gz
+├── release-notes.md
+├── rna-isoform-expression-rsem-tpm.rds
+├── snv-consensus-plus-hotspots.maf.tsv.gz
+├── snv-mutation-tmb-coding.tsv
+└── splice-events-rmats.tsv.gz
+```
+
+## previous release (v4)
+- Data release data: 2023-04-30
+- OpenPedCan data release date: 2023-04-30 (v12)
+- status: available
+
+Additional files:
+- `splice-events-rmats.tsv.gz`: merged matrix of rMATs splice events, run as single sample
+
+```
+v4
+├── cnv-consensus.seg.gz
+├── consensus_wgs_plus_cnvkit_wxs.tsv.gz
+├── fusion-putative-oncogenic.tsv
+├── gene-counts-rsem-expected_count-collapsed.rds
+├── gene-expression-rsem-tpm-collapsed.rds
+├── histologies.tsv
+├── independent-specimens.rnaseqpanel.primary-plus.tsv
+├── independent-specimens.rnaseqpanel.primary.tsv
+├── independent-specimens.wgswxspanel.primary-plus.prefer.wgs.tsv
+├── independent-specimens.wgswxspanel.primary-plus.prefer.wxs.tsv
+├── independent-specimens.wgswxspanel.primary.prefer.wgs.tsv
+├── independent-specimens.wgswxspanel.primary.prefer.wxs.tsv
+├── md5sum.txt
+├── rna-isoform-expression-rsem-tpm.rds
+├── snv-consensus-plus-hotspots.maf.tsv.gz
+├── snv-mutation-tmb-coding.tsv
+└── splice-events-rmats.tsv.gz
+```

--- a/download_data.sh
+++ b/download_data.sh
@@ -16,25 +16,6 @@ curl --create-dirs $URL/$RELEASE/md5sum.txt -o data/$RELEASE/md5sum.txt -z data/
 # Consider the filenames in the md5sum file and the release notes
 FILES=(`tr -s ' ' < data/$RELEASE/md5sum.txt | cut -d ' ' -f 2` release-notes.md)
 
-if [ -d "data/$PREVIOUS" ]
-then
-  # Find unchanged files
-  echo "Checking for unchanged files..."
-  cd data/$PREVIOUS
-  UNCHANGED=(`md5sum -c ../$RELEASE/md5sum.txt 2>/dev/null | grep OK |cut -d ':' -f 1  || true`)
-  echo $UNCHANGED
-  cd ../../
-
-  # Hard link unchanged files
-  for oldfile in "${UNCHANGED[@]}"
-  do
-    if [ ! -e "data/$RELEASE/$oldfile" ]
-    then
-      echo "Hard linking $oldfile"
-      ln data/$PREVIOUS/$oldfile data/$RELEASE/$oldfile
-    fi
-  done
-fi
 
 # Download the items in FILES if not already present
 for file in "${FILES[@]}"


### PR DESCRIPTION
Added rMATS_merged.comparison.tsv.gz file to v5. It seems as if everything downloads properly when running the `download_data.sh` script, but I do get the following warning: 

`md5sum: WARNING: 1 of 21 computed checksums did NOT match
`
I am sure what this means (may have not made the md5sum file correctly?